### PR TITLE
🔒 Add rel="noopener noreferrer" to external links

### DIFF
--- a/src/pages/leavenotrace/dogs.astro
+++ b/src/pages/leavenotrace/dogs.astro
@@ -132,6 +132,7 @@ const rules = [
                     <a
                       href={`https://instagram.com/${dog.handle}`}
                       target="_blank"
+                      rel="noopener noreferrer"
                     >
                       <Picture
                         src={dog.src}
@@ -155,6 +156,7 @@ const rules = [
                     <a
                       href={`https://instagram.com/${dog.handle}`}
                       target="_blank"
+                      rel="noopener noreferrer"
                     >
                       <Picture
                         src={dog.src}

--- a/src/pages/trailheads/[...slug].astro
+++ b/src/pages/trailheads/[...slug].astro
@@ -106,6 +106,7 @@ const { entry } = Astro.props;
                 <a
                   href={entry.data.directionsLink}
                   target="_blank"
+                  rel="noopener noreferrer"
                   class="btn-primary-cta inline-flex items-center justify-center w-full"
                 >
                   Get Directions →

--- a/src/pages/visit.astro
+++ b/src/pages/visit.astro
@@ -155,6 +155,7 @@ const sortedTrailheads = trailheads.sort((a, b) => a.data.id - b.data.id);
                 <a
                   href="/images/maps/ute-valley-park-map-full.jpg"
                   target="_blank"
+                  rel="noopener noreferrer"
                 >
                   <Picture
                     src={uteValleyParkMap}


### PR DESCRIPTION
🎯 **What:** Missing `rel="noopener noreferrer"` on anchor tags using `target="_blank"`.
⚠️ **Risk:** Potential "tabnabbing" vulnerability where a malicious page opened in a new tab could gain control over the original page via `window.opener`.
🛡️ **Solution:** Added `rel="noopener noreferrer"` to all identified external links that open in a new tab in `src/pages/visit.astro`, `src/pages/trailheads/[...slug].astro`, and `src/pages/leavenotrace/dogs.astro`.

---
*PR created automatically by Jules for task [8519626969440384258](https://jules.google.com/task/8519626969440384258) started by @drewtownchi*