### PR TITLE
Add nofollow rel attributes to all _blank links

### DIFF
--- a/src/components/LeaveNoTrace.astro
+++ b/src/components/LeaveNoTrace.astro
@@ -94,7 +94,7 @@ import lntLogo from "../assets/images/logos/leave-no-trace.png";
               <a
                 href="https://www.lnt.org"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener noreferrer nofollow"
               >
                 <Picture
                   src={lntLogo}

--- a/src/components/SocialLinks.astro
+++ b/src/components/SocialLinks.astro
@@ -30,7 +30,7 @@ const socialLinks = (await getCollection('social-links')).sort(
         href={entry.data.link}
         class={`inline-flex min-h-10 min-w-10 items-center justify-center border border-stone-300 bg-white p-2 text-stone-500 transition-[border-color,color,transform] duration-200 active:scale-96 ${hover}`}
         target="_blank"
-        rel="noopener noreferrer"
+        rel="noopener noreferrer nofollow"
       >
         <span class="sr-only">{entry.data.title}</span>
         <Icon class="h-5 w-5" aria-hidden="true" />

--- a/src/pages/leavenotrace/dogs.astro
+++ b/src/pages/leavenotrace/dogs.astro
@@ -132,6 +132,7 @@ const rules = [
                     <a
                       href={`https://instagram.com/${dog.handle}`}
                       target="_blank"
+                      rel="noopener noreferrer nofollow"
                     >
                       <Picture
                         src={dog.src}
@@ -155,6 +156,7 @@ const rules = [
                     <a
                       href={`https://instagram.com/${dog.handle}`}
                       target="_blank"
+                      rel="noopener noreferrer nofollow"
                     >
                       <Picture
                         src={dog.src}

--- a/src/pages/linkinbio.astro
+++ b/src/pages/linkinbio.astro
@@ -96,7 +96,7 @@ import Logo from "@/assets/images/logos/logo-medium.jpg";
               <a
                 href={link.data.link}
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener noreferrer nofollow"
                 class="group flex justify-between items-center p-5 border border-stone-300 bg-white hover:border-primary-dark transition-[background-color,border-color,color,box-shadow,transform] duration-200 active:scale-96"
               >
                 <span class="font-mono text-xs font-black uppercase tracking-widest text-stone-900 group-hover:text-primary-dark transition-colors">
@@ -153,7 +153,7 @@ import Logo from "@/assets/images/logos/logo-medium.jpg";
                     <a
                       href={item.data.link}
                       target="_blank"
-                      rel="noopener noreferrer"
+                      rel="noopener noreferrer nofollow"
                     >
                       {item.data.title}
                     </a>
@@ -176,4 +176,3 @@ import Logo from "@/assets/images/logos/logo-medium.jpg";
     </div>
   </main>
 </Layout>
-

--- a/src/pages/trailheads/[...slug].astro
+++ b/src/pages/trailheads/[...slug].astro
@@ -106,6 +106,7 @@ const { entry } = Astro.props;
                 <a
                   href={entry.data.directionsLink}
                   target="_blank"
+                  rel="noopener noreferrer nofollow"
                   class="btn-primary-cta inline-flex items-center justify-center w-full"
                 >
                   Get Directions →
@@ -168,4 +169,3 @@ const { entry } = Astro.props;
     </section>
   </main>
 </Layout>
-

--- a/src/pages/visit.astro
+++ b/src/pages/visit.astro
@@ -155,6 +155,7 @@ const sortedTrailheads = trailheads.sort((a, b) => a.data.id - b.data.id);
                 <a
                   href="/images/maps/ute-valley-park-map-full.jpg"
                   target="_blank"
+                  rel="noopener noreferrer nofollow"
                 >
                   <Picture
                     src={uteValleyParkMap}


### PR DESCRIPTION
## Summary
- Updated every `_blank` link in the affected Astro pages and components to include `rel="noopener noreferrer nofollow"`.
- Covered external social links, Instagram links, the Leave No Trace logo, trailhead directions, and the visit map link.

## Testing
- `pnpm run lint` passed.
- `pnpm run typecheck` passed.
- `pnpm run build` passed.